### PR TITLE
Clarify block/page terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+- Rename parts of the `DFUMemIO` API to remove confusing block/page terminology. ([#4])(https://github.com/vitalyvb/usbd-dfu/pull/4)
+- Rename `Command::EraseBlock` to `Command::Erase`. ([#4])(https://github.com/vitalyvb/usbd-dfu/pull/4)
+
 ## [0.1.1] - 2021-05-15
 ### Added
 - CI using GitHub Actions

--- a/README.md
+++ b/README.md
@@ -79,27 +79,27 @@ struct MyMem {
 impl DFUMemIO for MyMem {
     const MEM_INFO_STRING: &'static str = "@Flash/0x00000000/1*1Kg";
     const INITIAL_ADDRESS_POINTER: u32 = 0x0;
-    const PAGE_PROGRAM_TIME_MS: u32 = 8;
-    const PAGE_ERASE_TIME_MS: u32 = 50;
+    const PROGRAM_TIME_MS: u32 = 8;
+    const ERASE_TIME_MS: u32 = 50;
     const FULL_ERASE_TIME_MS: u32 = 50;
     const TRANSFER_SIZE: u16 = 64;
 
-    fn read_block(&mut self, address: u32, length: usize) -> Result<&[u8], DFUMemError> {
+    fn read(&mut self, address: u32, length: usize) -> Result<&[u8], DFUMemError> {
         // TODO: check address value
         let offset = address as usize;
         Ok(&self.flash_memory[offset..offset+length])
     }
 
-    fn erase_block(&mut self, address: u32) -> Result<(), DFUMemError> {
+    fn erase(&mut self, address: u32) -> Result<(), DFUMemError> {
         // TODO: check address value
         self.flash_memory.fill(0xff);
         // TODO: verify that block is erased successfully
         Ok(())
     }
 
-    fn erase_all_blocks(&mut self) -> Result<(), DFUMemError> {
+    fn erase_all(&mut self) -> Result<(), DFUMemError> {
         // There is only one block, erase it.
-        self.erase_block(0)
+        self.erase(0)
     }
 
     fn store_write_buffer(&mut self, src:&[u8]) -> Result<(), ()>{
@@ -107,7 +107,7 @@ impl DFUMemIO for MyMem {
         Ok(())
     }
 
-    fn program_block(&mut self, address: u32, length: usize) -> Result<(), DFUMemError>{
+    fn program(&mut self, address: u32, length: usize) -> Result<(), DFUMemError>{
         // TODO: check address value
         let offset = address as usize;
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -166,9 +166,9 @@ pub trait DFUMemIO {
     ///
     /// > *address* - Memory address of a regions, e.g. "0x08000000"
     ///
-    /// > *area* - count of blocks, block size, and supported operations for the region, e.g. 8*1Ke - 8 blocks of 1024 bytes, available for reading and writing.
+    /// > *area* - count of pages, page size, and supported operations for the region, e.g. 8*1Ke - 8 pages of 1024 bytes, available for reading and writing.
     ///
-    /// Block size supports these suffixes: **K**, **M**, **G**, or ` ` (space) for bytes.
+    /// Page size supports these suffixes: **K**, **M**, **G**, or ` ` (space) for bytes.
     ///
     /// And a letter that specifies region's supported operation:
     ///
@@ -188,8 +188,8 @@ pub trait DFUMemIO {
     /// ```
     ///
     /// Denotes a memory region named "Flash", with a starting address `0x08000000`,
-    /// the first 16 blocks with a size 1K are available only for reading, and the next
-    /// 48 1K-blocks are avaiable for reading, erase, and write operations.
+    /// the first 16 pages with a size 1K are available only for reading, and the next
+    /// 48 1K-pages are avaiable for reading, erase, and write operations.
     const MEM_INFO_STRING: &'static str;
 
     /// If set, DFU descriptor will have *bitCanDnload* bit set. Default is `true`.
@@ -226,12 +226,12 @@ pub trait DFUMemIO {
     /// >    before issuing the next command. Device, after submitting a reply
     /// >    starts program operation.
     /// > 4. After waiting for a specified number of milliseconds, host continues to send new commands.
-    const PAGE_PROGRAM_TIME_MS: u32;
+    const BLOCK_PROGRAM_TIME_MS: u32;
 
-    /// Similar to [`PAGE_PROGRAM_TIME_MS`](DFUMemIO::PAGE_PROGRAM_TIME_MS), but for a block erase operation.
+    /// Similar to [`BLOCK_PROGRAM_TIME_MS`](DFUMemIO::BLOCK_PROGRAM_TIME_MS), but for a page erase operation.
     const PAGE_ERASE_TIME_MS: u32;
 
-    /// Similar to [`PAGE_PROGRAM_TIME_MS`](DFUMemIO::PAGE_PROGRAM_TIME_MS), but for a full erase operation.
+    /// Similar to [`BLOCK_PROGRAM_TIME_MS`](DFUMemIO::BLOCK_PROGRAM_TIME_MS), but for a full erase operation.
     const FULL_ERASE_TIME_MS: u32;
 
     /// Time in milliseconds host must wait after submitting the final firware download
@@ -244,7 +244,7 @@ pub trait DFUMemIO {
     /// [`MANIFESTATION_TOLERANT`](DFUMemIO::MANIFESTATION_TOLERANT) is `false`), or it can return to IDLE state
     /// (if `MANIFESTATION_TOLERANT` is `true`)
     ///
-    /// See also [`PAGE_PROGRAM_TIME_MS`](DFUMemIO::PAGE_PROGRAM_TIME_MS).
+    /// See also [`BLOCK_PROGRAM_TIME_MS`](DFUMemIO::BLOCK_PROGRAM_TIME_MS).
     const MANIFESTATION_TIME_MS: u32 = 1;
 
     /// wDetachTimeOut field in DFU descriptor. Default value: `250` ms.
@@ -308,7 +308,7 @@ pub trait DFUMemIO {
     ///
     fn program_block(&mut self, address: u32, length: usize) -> Result<(), DFUMemError>;
 
-    /// Trigger block erase.
+    /// Trigger page erase.
     ///
     /// Implementation must ensure that address is valid, or return an error.
     ///
@@ -316,7 +316,7 @@ pub trait DFUMemIO {
     // / This function by default is called from USB interrupt context, depending on
     // / [`MEMIO_IN_USB_INTERRUPT`](DFUMemIO::MEMIO_IN_USB_INTERRUPT) value.
     ///
-    fn erase_block(&mut self, address: u32) -> Result<(), DFUMemError>;
+    fn erase_page(&mut self, address: u32) -> Result<(), DFUMemError>;
 
     /// Trigger full erase.
     ///
@@ -324,7 +324,7 @@ pub trait DFUMemIO {
     // / This function by default is called from USB interrupt context, depending on
     // / [`MEMIO_IN_USB_INTERRUPT`](DFUMemIO::MEMIO_IN_USB_INTERRUPT) value.
     ///
-    fn erase_all_blocks(&mut self) -> Result<(), DFUMemError>;
+    fn erase_all_pages(&mut self) -> Result<(), DFUMemError>;
 
     /// Finish writing firmware to a persistent storage, and optionally activate it.
     ///

--- a/src/class.rs
+++ b/src/class.rs
@@ -140,11 +140,12 @@ pub enum DFUManifestationError {
     Unknown = DFUStatusCode::ErrUnknown as u8,
 }
 
-/// Trait that describes the abstraction used to access memory
-/// on a device. [`DFUClass`] will call corresponding
-/// functions and will use provided constants to tailor
-/// DFU features and, for example time interval values that
+/// Trait that describes the abstraction used to access memory on a device. [`DFUClass`] will call corresponding
+/// functions and will use provided constants to tailor DFU features and, for example time interval values that
 /// are used in the protocol.
+///
+/// In this context we use "page" to mean the smallest region of flash memory which can be erased, and "block"
+/// to mean an amount of memory which is to be used for reading or programming.
 pub trait DFUMemIO {
     /// Specifies the default value of Address Pointer
     ///
@@ -226,12 +227,12 @@ pub trait DFUMemIO {
     /// >    before issuing the next command. Device, after submitting a reply
     /// >    starts program operation.
     /// > 4. After waiting for a specified number of milliseconds, host continues to send new commands.
-    const BLOCK_PROGRAM_TIME_MS: u32;
+    const PROGRAM_TIME_MS: u32;
 
-    /// Similar to [`BLOCK_PROGRAM_TIME_MS`](DFUMemIO::BLOCK_PROGRAM_TIME_MS), but for a page erase operation.
-    const PAGE_ERASE_TIME_MS: u32;
+    /// Similar to [`PROGRAM_TIME_MS`](DFUMemIO::PROGRAM_TIME_MS), but for a page erase operation.
+    const ERASE_TIME_MS: u32;
 
-    /// Similar to [`BLOCK_PROGRAM_TIME_MS`](DFUMemIO::BLOCK_PROGRAM_TIME_MS), but for a full erase operation.
+    /// Similar to [`PROGRAM_TIME_MS`](DFUMemIO::PROGRAM_TIME_MS), but for a full erase operation.
     const FULL_ERASE_TIME_MS: u32;
 
     /// Time in milliseconds host must wait after submitting the final firware download
@@ -244,7 +245,7 @@ pub trait DFUMemIO {
     /// [`MANIFESTATION_TOLERANT`](DFUMemIO::MANIFESTATION_TOLERANT) is `false`), or it can return to IDLE state
     /// (if `MANIFESTATION_TOLERANT` is `true`)
     ///
-    /// See also [`BLOCK_PROGRAM_TIME_MS`](DFUMemIO::BLOCK_PROGRAM_TIME_MS).
+    /// See also [`PROGRAM_TIME_MS`](DFUMemIO::PROGRAM_TIME_MS).
     const MANIFESTATION_TIME_MS: u32 = 1;
 
     /// wDetachTimeOut field in DFU descriptor. Default value: `250` ms.
@@ -258,7 +259,7 @@ pub trait DFUMemIO {
 
     /// Maximum allowed transfer size. Default value: `128` bytes.
     ///
-    /// This is the maximum size of a block for [`read_block()`](DFUMemIO::read_block) and [`program_block()`](DFUMemIO::program_block) functions.
+    /// This is the maximum size of a block for [`read()`](DFUMemIO::read) and [`program()`](DFUMemIO::program) functions.
     ///
     /// All DFU transfers use Control endpoint only.
     ///
@@ -295,7 +296,7 @@ pub trait DFUMemIO {
     ///
     /// This function is called from `usb_dev.poll([])` (USB interrupt context).
     ///
-    fn read_block(&mut self, address: u32, length: usize) -> Result<&[u8], DFUMemError>;
+    fn read(&mut self, address: u32, length: usize) -> Result<&[u8], DFUMemError>;
 
     /// Trigger block program
     ///
@@ -306,7 +307,7 @@ pub trait DFUMemIO {
     // / This function by default is called from USB interrupt context, depending on
     // / [`MEMIO_IN_USB_INTERRUPT`](DFUMemIO::MEMIO_IN_USB_INTERRUPT) value.
     ///
-    fn program_block(&mut self, address: u32, length: usize) -> Result<(), DFUMemError>;
+    fn program(&mut self, address: u32, length: usize) -> Result<(), DFUMemError>;
 
     /// Trigger page erase.
     ///
@@ -316,7 +317,7 @@ pub trait DFUMemIO {
     // / This function by default is called from USB interrupt context, depending on
     // / [`MEMIO_IN_USB_INTERRUPT`](DFUMemIO::MEMIO_IN_USB_INTERRUPT) value.
     ///
-    fn erase_page(&mut self, address: u32) -> Result<(), DFUMemError>;
+    fn erase(&mut self, address: u32) -> Result<(), DFUMemError>;
 
     /// Trigger full erase.
     ///
@@ -324,7 +325,7 @@ pub trait DFUMemIO {
     // / This function by default is called from USB interrupt context, depending on
     // / [`MEMIO_IN_USB_INTERRUPT`](DFUMemIO::MEMIO_IN_USB_INTERRUPT) value.
     ///
-    fn erase_all_pages(&mut self) -> Result<(), DFUMemError>;
+    fn erase_all(&mut self) -> Result<(), DFUMemError>;
 
     /// Finish writing firmware to a persistent storage, and optionally activate it.
     ///
@@ -801,7 +802,7 @@ impl<B: UsbBus, M: DFUMemIO> DFUClass<B, M> {
                 .address_pointer
                 .checked_add((block_num as u32) * (transfer_size as u32))
             {
-                match self.mem.read_block(address, transfer_size as usize) {
+                match self.mem.read(address, transfer_size as usize) {
                     Ok(b) => {
                         if b.len() < M::TRANSFER_SIZE as usize {
                             // short frame, back to idle
@@ -862,9 +863,9 @@ impl<B: UsbBus, M: DFUMemIO> DFUClass<B, M> {
             Command::WriteMemory {
                 block_num: _,
                 len: _,
-            } => M::PAGE_PROGRAM_TIME_MS,
+            } => M::PROGRAM_TIME_MS,
             Command::EraseAll => M::FULL_ERASE_TIME_MS,
-            Command::EraseBlock(_) => M::PAGE_ERASE_TIME_MS,
+            Command::EraseBlock(_) => M::ERASE_TIME_MS,
             Command::LeaveDFU => M::MANIFESTATION_TIME_MS,
             _ => 0,
         }
@@ -899,11 +900,11 @@ impl<B: UsbBus, M: DFUMemIO> DFUClass<B, M> {
 
     fn update_impl(&mut self) {
         match self.status.pending {
-            Command::EraseAll => match self.mem.erase_all_blocks() {
+            Command::EraseAll => match self.mem.erase_all() {
                 Err(e) => self.status.new_state_status(DFUState::DfuError, e.into()),
                 Ok(_) => self.status.new_state_ok(DFUState::DfuDnloadSync),
             },
-            Command::EraseBlock(b) => match self.mem.erase_block(b) {
+            Command::EraseBlock(b) => match self.mem.erase(b) {
                 Err(e) => self.status.new_state_status(DFUState::DfuError, e.into()),
                 Ok(_) => self.status.new_state_ok(DFUState::DfuDnloadSync),
             },
@@ -934,7 +935,7 @@ impl<B: UsbBus, M: DFUMemIO> DFUClass<B, M> {
                     .address_pointer
                     .checked_add((block_num as u32) * (len as u32))
                 {
-                    match self.mem.program_block(pointer, len as usize) {
+                    match self.mem.program(pointer, len as usize) {
                         Err(e) => self.status.new_state_status(DFUState::DfuError, e.into()),
                         Ok(_) => self.status.new_state_ok(DFUState::DfuDnloadSync),
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,27 +85,27 @@
 //! impl DFUMemIO for MyMem {
 //!     const MEM_INFO_STRING: &'static str = "@Flash/0x00000000/1*1Kg";
 //!     const INITIAL_ADDRESS_POINTER: u32 = 0x0;
-//!     const PAGE_PROGRAM_TIME_MS: u32 = 8;
-//!     const PAGE_ERASE_TIME_MS: u32 = 50;
+//!     const PROGRAM_TIME_MS: u32 = 8;
+//!     const ERASE_TIME_MS: u32 = 50;
 //!     const FULL_ERASE_TIME_MS: u32 = 50;
 //!     const TRANSFER_SIZE: u16 = 64;
 //!
-//!     fn read_block(&mut self, address: u32, length: usize) -> Result<&[u8], DFUMemError> {
+//!     fn read(&mut self, address: u32, length: usize) -> Result<&[u8], DFUMemError> {
 //!         // TODO: check address value
 //!         let offset = address as usize;
 //!         Ok(&self.flash_memory[offset..offset+length])
 //!     }
 //!
-//!     fn erase_block(&mut self, address: u32) -> Result<(), DFUMemError> {
+//!     fn erase(&mut self, address: u32) -> Result<(), DFUMemError> {
 //!         // TODO: check address value
 //!         self.flash_memory.fill(0xff);
 //!         // TODO: verify that block is erased successfully
 //!         Ok(())
 //!     }
 //!
-//!     fn erase_all_blocks(&mut self) -> Result<(), DFUMemError> {
+//!     fn erase_all(&mut self) -> Result<(), DFUMemError> {
 //!         // There is only one block, erase it.
-//!         self.erase_block(0)
+//!         self.erase(0)
 //!     }
 //!
 //!     fn store_write_buffer(&mut self, src:&[u8]) -> Result<(), ()>{
@@ -113,7 +113,7 @@
 //!         Ok(())
 //!     }
 //!
-//!     fn program_block(&mut self, address: u32, length: usize) -> Result<(), DFUMemError>{
+//!     fn program(&mut self, address: u32, length: usize) -> Result<(), DFUMemError>{
 //!         // TODO: check address value
 //!         let offset = address as usize;
 //!

--- a/tests/dfu_mt_tests.rs
+++ b/tests/dfu_mt_tests.rs
@@ -17,8 +17,8 @@ impl DFUMemIO for TestMem {
     const INITIAL_ADDRESS_POINTER: u32 = TESTMEM_BASE;
     const MANIFESTATION_TOLERANT: bool = true;
     const MANIFESTATION_TIME_MS: u32 = 0x123;
-    const PAGE_PROGRAM_TIME_MS: u32 = 0;
-    const PAGE_ERASE_TIME_MS: u32 = 0;
+    const PROGRAM_TIME_MS: u32 = 0;
+    const ERASE_TIME_MS: u32 = 0;
     const FULL_ERASE_TIME_MS: u32 = 0;
     const MEM_INFO_STRING: &'static str = "@Flash/0x02000000/16*1Ka,48*1Kg";
     const HAS_DOWNLOAD: bool = false;
@@ -27,19 +27,15 @@ impl DFUMemIO for TestMem {
     const TRANSFER_SIZE: u16 = 128;
     // const MEMIO_IN_USB_INTERRUPT: bool = false;
 
-    fn read_block(
-        &mut self,
-        address: u32,
-        length: usize,
-    ) -> core::result::Result<&[u8], DFUMemError> {
+    fn read(&mut self, address: u32, length: usize) -> core::result::Result<&[u8], DFUMemError> {
         Err(DFUMemError::Address)
     }
 
-    fn erase_block(&mut self, address: u32) -> core::result::Result<(), DFUMemError> {
+    fn erase(&mut self, address: u32) -> core::result::Result<(), DFUMemError> {
         Ok(())
     }
 
-    fn erase_all_blocks(&mut self) -> Result<(), DFUMemError> {
+    fn erase_all(&mut self) -> Result<(), DFUMemError> {
         Ok(())
     }
 
@@ -47,11 +43,7 @@ impl DFUMemIO for TestMem {
         Ok(())
     }
 
-    fn program_block(
-        &mut self,
-        address: u32,
-        length: usize,
-    ) -> core::result::Result<(), DFUMemError> {
+    fn program(&mut self, address: u32, length: usize) -> core::result::Result<(), DFUMemError> {
         Err(DFUMemError::Address)
     }
 


### PR DESCRIPTION
I was confused by the documentation of `DFUMemIO` because it seems to use "block" and "page" interchangeably. I wanted to clarify the terminology used and settled on the following:

A "block" is the largest buffer that can be read or programmed. A "page" is the smallest region of flash memory that can be erased.