### PR TITLE
Address must be calculated on TRANSFER_SIZE and not on payload len

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -800,7 +800,7 @@ impl<B: UsbBus, M: DFUMemIO> DFUClass<B, M> {
             if let Some(address) = self
                 .status
                 .address_pointer
-                .checked_add((block_num as u32) * (transfer_size as u32))
+                .checked_add((block_num as u32) * (M::TRANSFER_SIZE as u32))
             {
                 match self.mem.read(address, transfer_size as usize) {
                     Ok(b) => {
@@ -933,7 +933,7 @@ impl<B: UsbBus, M: DFUMemIO> DFUClass<B, M> {
                 if let Some(pointer) = self
                     .status
                     .address_pointer
-                    .checked_add((block_num as u32) * (len as u32))
+                    .checked_add((block_num as u32) * (M::TRANSFER_SIZE as u32))
                 {
                     match self.mem.program(pointer, len as usize) {
                         Err(e) => self.status.new_state_status(DFUState::DfuError, e.into()),


### PR DESCRIPTION
Otherwise during the download of the last bit of payload, the flash address calculation is incorrect. i.e.:

   Write to block 0, len = 128 writes to 0x0000
   Write to block 1, len = 128 writes to 0x0080
   Write to block 2, len = 16  tries to write to 0x0020 (oops!), and programming error happens.

I found this while trying to use usbd-dfu with https://fwupd.org in Linux.

Ps @vitalyvb I see you are from Ukraine, I hope everything is ok for your family and that you are ok, my best wishes.