### PR TITLE
Update github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all
+      - run: cargo +${{steps.toolchain.outputs.name}} fmt --all -- --check
+      - run: cargo +${{steps.toolchain.outputs.name}} clippy --all
 
   build_only:
     runs-on: ubuntu-latest
@@ -41,11 +42,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: dtolnay/rust-toolchain@master
+        id: toolchain
         with:
           toolchain: ${{ matrix.rust }}
           targets: thumbv7m-none-eabi
 
-      - run: cargo build --target thumbv7m-none-eabi
+      - run: cargo +${{steps.toolchain.outputs.name}} build --target thumbv7m-none-eabi
 
 #  tests:
 #    needs: [build_only]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install 32-bit build dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libc6-dev-i386
+
       - uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,36 +49,32 @@ jobs:
 
       - run: cargo +${{steps.toolchain.outputs.name}} build --target thumbv7m-none-eabi
 
-#  tests:
-#    needs: [build_only]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        target:
-#          - x86_64-unknown-linux-gnu
-#          - i686-unknown-linux-gnu
-#        rust:
-#          - stable
-#          - nightly
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          target: ${{ matrix.target }}
-#          override: true
-#
-#      - uses: actions-rs/cargo@v1
-#        with:
-#          command: build
-#
-#      - uses: actions-rs/cargo@v1
-#        with:
-#          command: test
-#
+  tests:
+    needs: [build_only]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@master
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: "x86_64-unknown-linux-gnu,i686-unknown-linux-gnu"
+
+      - run: cargo +${{steps.toolchain.outputs.name}} build --target x86_64-unknown-linux-gnu
+      - run: cargo +${{steps.toolchain.outputs.name}} test --target x86_64-unknown-linux-gnu
+
+      - run: cargo clean
+
+      - run: cargo +${{steps.toolchain.outputs.name}} build --target i686-unknown-linux-gnu
+      - run: cargo +${{steps.toolchain.outputs.name}} test --target i686-unknown-linux-gnu
+
 #  docs:
 #    needs: [build_only]
 #    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@${{ matrix.rust }}
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
       - run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 on:
   push:
-    branches: [ main ]
+#    branches: [ main ]
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron:  '12 10 9 * *'
+#  schedule:
+#    - cron:  '12 10 9 * *'
 
 name: Continuous integration
 
@@ -19,96 +19,86 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@${{ matrix.rust }}
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt, clippy
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all
+#  build_only:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        target:
+#          - thumbv7m-none-eabi
+#        rust:
+#          - stable
+#          - nightly
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          target: ${{ matrix.target }}
+#          override: true
+#
+#      - uses: actions-rs/cargo@v1
+#        with:
+#          command: build
 
-  build_only:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - thumbv7m-none-eabi
-        rust:
-          - stable
-          - nightly
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-
-  tests:
-    needs: [build_only]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
-        rust:
-          - stable
-          - nightly
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-  docs:
-    needs: [build_only]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
+#  tests:
+#    needs: [build_only]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        target:
+#          - x86_64-unknown-linux-gnu
+#          - i686-unknown-linux-gnu
+#        rust:
+#          - stable
+#          - nightly
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          target: ${{ matrix.target }}
+#          override: true
+#
+#      - uses: actions-rs/cargo@v1
+#        with:
+#          command: build
+#
+#      - uses: actions-rs/cargo@v1
+#        with:
+#          command: test
+#
+#  docs:
+#    needs: [build_only]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        rust:
+#          - stable
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          override: true
+#
+#      - uses: actions-rs/cargo@v1
+#        with:
+#          command: doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,29 +29,23 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all
 
-#  build_only:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        target:
-#          - thumbv7m-none-eabi
-#        rust:
-#          - stable
-#          - nightly
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          target: ${{ matrix.target }}
-#          override: true
-#
-#      - uses: actions-rs/cargo@v1
-#        with:
-#          command: build
+  build_only:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          targets: thumbv7m-none-eabi
+
+      - run: cargo build --target thumbv7m-none-eabi
 
 #  tests:
 #    needs: [build_only]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,29 +74,9 @@ jobs:
 
       - run: cargo +${{steps.toolchain.outputs.name}} build --target x86_64-unknown-linux-gnu
       - run: cargo +${{steps.toolchain.outputs.name}} test --target x86_64-unknown-linux-gnu
+      - run: cargo +${{steps.toolchain.outputs.name}} doc --target x86_64-unknown-linux-gnu
 
       - run: cargo clean
 
       - run: cargo +${{steps.toolchain.outputs.name}} build --target i686-unknown-linux-gnu
       - run: cargo +${{steps.toolchain.outputs.name}} test --target i686-unknown-linux-gnu
-
-#  docs:
-#    needs: [build_only]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        rust:
-#          - stable
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          override: true
-#
-#      - uses: actions-rs/cargo@v1
-#        with:
-#          command: doc

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    tags:
+      - "v0.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+name: Publish release tag to crates.io
+
+jobs:
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check package version
+        run: |
+          cat Cargo.toml | gawk -v ver="$GITHUB_REF_NAME" -F= 'BEGIN {res=1;p=0} /^\[/ {p=0} /^\[package\]/ {p=1} /^version/ {if (p) {gsub(/[" ]/,"", $2); fver="v"$2; if (fver==ver) {res=0}}} END {exit res}'
+
+      - uses: dtolnay/rust-toolchain@stable
+        id: toolchain
+        with:
+          targets: thumbv7m-none-eabi
+
+      - run: cargo +${{steps.toolchain.outputs.name}} publish --target thumbv7m-none-eabi --dry-run
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
- actions-rs/toolchain is no longer supported, use dtolnay/rust-toolchain
- fix running tests on i686 (was running on x86_64 in fact)
- drop docs job and build docs in tests job
- add not yet tested publish release workflow