### PR TITLE
Update to usb-device 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `usb-device` dependency updated to 0.3.1
 - Created CREDITS.md
 - Updated README.md and copyright notice in LICENSE file
 - Bump tests dependency stm32f1xx-hal to 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - yyyy-mm-dd
 
+### Breaking Changes
+- `usb-device` dependency updated to 0.3.1. No API changes in `usbd-dfu`,
+however, there may be type compatibility issues if anything else
+depends on `usb-device` 0.2.x
+
 ### Changed
-- `usb-device` dependency updated to 0.3.1
 - Created CREDITS.md
 - Updated README.md and copyright notice in LICENSE file
 - Remove dev-dependency on stm32f1xx-hal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - yyyy-mm-dd
+
 ### Changed
 - `usb-device` dependency updated to 0.3.1
 - Created CREDITS.md
@@ -69,7 +71,8 @@ command ([#6](https://github.com/vitalyvb/usbd-dfu/pull/6))
 
 First version.
 
-[Unreleased]: https://github.com/vitalyvb/usbd-dfu/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/vitalyvb/usbd-dfu/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/vitalyvb/usbd-dfu/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/vitalyvb/usbd-dfu/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/vitalyvb/usbd-dfu/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/vitalyvb/usbd-dfu/compare/v0.1.1...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `usb-device` dependency updated to 0.3.1
 - Created CREDITS.md
 - Updated README.md and copyright notice in LICENSE file
-- Bump tests dependency stm32f1xx-hal to 0.10.0
+- Remove dev-dependency on stm32f1xx-hal
 
 ## [0.3.1] - 2023-05-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usbd-dfu"
 description = "DFU protocol for a `usb-device` device."
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Vitalii Bursov <vitaly@bursov.com>"]
 edition = "2021"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,3 @@ exclude = [
 
 [dependencies.usb-device]
 version = "0.3.1"
-
-[dev-dependencies.stm32f1xx-hal]
-version = "0.10.0"
-features = ["rt", "stm32f103", "medium", "stm32-usbd"]
-
-[patch.crates-io]
-stm32-usbd = { git = "https://github.com/vitalyvb/stm32-usbd.git", branch = "usb-device-3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ exclude = [
 ]
 
 [dependencies.usb-device]
-version = "0.2.9"
+version = "0.3.1"
 
 [dev-dependencies.stm32f1xx-hal]
 version = "0.10.0"
 features = ["rt", "stm32f103", "medium", "stm32-usbd"]
+
+[patch.crates-io]
+stm32-usbd = { git = "https://github.com/vitalyvb/stm32-usbd.git", branch = "usb-device-3" }

--- a/README.md
+++ b/README.md
@@ -53,11 +53,14 @@ supporting DFU protocol, for example:
 
 ## License
 
-This project is licensed under [MIT License](https://opensource.org/licenses/MIT) ([LICENSE](https://github.com/vitalyvb/usbd-dfu/blob/main/LICENSE)).
+This project is licensed under [MIT License](https://opensource.org/licenses/MIT)
+([LICENSE](https://github.com/vitalyvb/usbd-dfu/blob/main/LICENSE)).
 
 ### Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you shall be licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you shall be licensed as above,
+without any additional terms or conditions.
 
 ## Example
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -821,7 +821,7 @@ impl<B: UsbBus, M: DFUMemIO> DFUClass<B, M> {
                         } else {
                             self.status.new_state_ok(DFUState::DfuUploadIdle);
                         }
-                        xfer.accept_with(&b).ok();
+                        xfer.accept_with(b).ok();
                         return;
                     }
                     Err(e) => {

--- a/src/class.rs
+++ b/src/class.rs
@@ -514,10 +514,8 @@ impl<B: UsbBus, M: DFUMemIO> UsbClass<B> for DFUClass<B, M> {
         Ok(())
     }
 
-    fn get_string(&self, index: StringIndex, lang_id: u16) -> Option<&str> {
-        if (lang_id == usb_device::descriptor::lang_id::ENGLISH_US || lang_id == 0)
-            && (index == self.interface_string)
-        {
+    fn get_string(&self, index: StringIndex, lang_id: LangID) -> Option<&str> {
+        if index == self.interface_string && lang_id == LangID::EN_US {
             return Some(M::MEM_INFO_STRING);
         }
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,11 +66,25 @@
 //! use usb_device::prelude::*;
 //! use usbd_dfu::*;
 //! #
-//! # use usb_device::prelude::*;
 //! # use usb_device::bus::UsbBusAllocator;
-//! # use stm32f1xx_hal::usb::{Peripheral, UsbBus, UsbBusType};
 //! #
-//! # let usb_bus_alloc: UsbBusAllocator<UsbBus<Peripheral>> = unsafe { core::mem::MaybeUninit::<UsbBusAllocator<UsbBus<Peripheral>>>::uninit().assume_init() };
+//! # pub struct DummyUsbBus { }
+//! # impl usb_device::bus::UsbBus for DummyUsbBus {
+//! #     fn alloc_ep(&mut self, _: usb_device::UsbDirection, _: Option<usb_device::endpoint::EndpointAddress>,
+//! #                 _: usb_device::endpoint::EndpointType, _: u16, _: u8) -> usb_device::Result<usb_device::endpoint::EndpointAddress> { todo!() }
+//! #     fn enable(&mut self) { todo!() }
+//! #     fn reset(&self) { todo!() }
+//! #     fn set_device_address(&self, _: u8) { todo!() }
+//! #     fn write(&self, _: usb_device::endpoint::EndpointAddress, _: &[u8]) -> usb_device::Result<usize> { todo!() }
+//! #     fn read(&self, _: usb_device::endpoint::EndpointAddress, _: &mut [u8]) -> usb_device::Result<usize> { todo!() }
+//! #     fn set_stalled(&self, _: usb_device::endpoint::EndpointAddress, _: bool) { todo!() }
+//! #     fn is_stalled(&self, _: usb_device::endpoint::EndpointAddress) -> bool { todo!() }
+//! #     fn suspend(&self) { todo!() }
+//! #     fn resume(&self) { todo!() }
+//! #     fn poll(&self) -> usb_device::bus::PollResult { todo!() }
+//! # }
+//! #
+//! # let usb_bus_alloc: UsbBusAllocator<DummyUsbBus> = unsafe { core::mem::MaybeUninit::<UsbBusAllocator<DummyUsbBus>>::uninit().assume_init() };
 //! # let mut usb_dev = UsbDeviceBuilder::new(&usb_bus_alloc, UsbVidPid(0, 0)).build();
 //!
 //! // DFUClass will use MyMem to actually read, erase or program the memory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,16 @@
 //! * [dfu-util](http://dfu-util.sourceforge.net/)
 //! * others
 //!
+//! ## License
+//!
+//! This project is licensed under [MIT License](https://opensource.org/licenses/MIT)
+//! ([LICENSE](https://github.com/vitalyvb/usbd-dfu/blob/main/LICENSE)).
+//!
+//! ### Contribution
+//!
+//! Unless you explicitly state otherwise, any contribution intentionally
+//! submitted for inclusion in the work by you shall be licensed as above,
+//! without any additional terms or conditions.
 //!
 //! ## Example
 //!

--- a/tests/dfu_tests.rs
+++ b/tests/dfu_tests.rs
@@ -238,8 +238,13 @@ fn test_get_configuration() {
             ]
         );
 
+        // get string descriptor languages
+        len = transact(&mut dfu, &[0x80, 0x6, 0, 3, 0, 0, 0x80, 0], None, &mut buf).expect("len");
+        assert_eq!(len, 4);
+        assert_eq!(&buf[0..4], &[len as u8, 3u8, 9, 4]); // 0x409 = EN_US
+
         // get string descriptor
-        len = transact(&mut dfu, &[0x80, 0x6, 4, 3, 0, 0, 0x80, 0], None, &mut buf).expect("len");
+        len = transact(&mut dfu, &[0x80, 0x6, 4, 3, 9, 4, 0x80, 0], None, &mut buf).expect("len");
         assert_eq!(len, 2 + TestMem::MEM_INFO_STRING.len() * 2);
         assert_eq!(&buf[0..2], &[len as u8, 3u8]);
         let u16v: Vec<_> = buf[2..len]

--- a/tests/mockusb/mod.rs
+++ b/tests/mockusb/mod.rs
@@ -291,13 +291,17 @@ pub fn with_usb<T, M>(
     let mut cls = maker.create(&alloc);
 
     let mut usb_dev = UsbDeviceBuilder::new(&alloc, UsbVidPid(0x1234, 0x1234))
-        .manufacturer("Test")
-        .product("Test")
-        .serial_number("Test")
+        .strings(&[StringDescriptors::default()
+            .manufacturer("Test")
+            .product("Test")
+            .serial_number("Test")])
+        .unwrap()
         .device_release(0x0200)
         .self_powered(false)
         .max_power(250)
+        .unwrap()
         .max_packet_size_0(EP0_SIZE)
+        .unwrap()
         .build();
 
     usb_dev.poll(&mut [&mut cls]);


### PR DESCRIPTION
- [ ] ~dev-dependencies support usb-device 0.3.x~
- [x] update dev-dependencies
- [x] Remove patch.crates-io for stm32-usbd from Cargo.toml
